### PR TITLE
Update tdiinpe.cls

### DIFF
--- a/monografia/template/tdiinpe.cls
+++ b/monografia/template/tdiinpe.cls
@@ -22,6 +22,11 @@
 
 \usepackage{ifpdf} 
 
+%%% Criando uma variável para definir se a cópia é digital ou não %%%
+\newif\ifdigitalcopy
+\digitalcopyfalse % Por padrão, não é uma cópia digital
+
+
 %%% Checa se foi chamado o comando htlatex para gerar documento em html
 \newif\ifHTML
   \ifx\HCode\undefined
@@ -510,7 +515,10 @@ top=3cm,bottom=3cm]{geometry}	% acrescentado por gjfb em 2011-12-06
 	\markboth{}{}
 
 \renewcommand{\chapter}{
-	\ifthenelse{\equal{\@folhaembranco}{true}}{
+    \ifdigitalcopy % Se for uma cópia digital
+        \clearpage % Use apenas clearpage
+    \else % Caso contrário, mantenha o comportamento original
+        \ifthenelse{\equal{\@folhaembranco}{true}{
 		\if@openright\cleardoublepage\else\clearpage\fi %% faz capitulo começar em folha impar (coloca folha em branco)
 	}{\vspace{\baselsinpe}}
 	\thispagestyle{\estilonum} %% define estilo de num. na pag. das partes 
@@ -595,8 +603,12 @@ top=3cm,bottom=3cm]{geometry}	% acrescentado por gjfb em 2011-12-06
 %%%%%%% tira num page de empty pages %%%%%%%%%%
 \let\origdoublepage\cleardoublepage
 \newcommand{\clearemptydoublepage}{%
-  \clearpage
-  {\pagestyle{empty}\origdoublepage}%
+    \ifdigitalcopy % Se for uma cópia digital
+        \clearpage % Use apenas clearpage
+    \else % Caso contrário, mantenha o comportamento original
+        \cleardoublepage
+        {\pagestyle{empty}\origdoublepage}%
+    \fi
 }
 \let\cleardoublepage\clearemptydoublepage
 %se nao ativo, comentar linhas acima e descomentar linhas abaixo

--- a/monografia/template/tdiinpe.cls
+++ b/monografia/template/tdiinpe.cls
@@ -518,7 +518,7 @@ top=3cm,bottom=3cm]{geometry}	% acrescentado por gjfb em 2011-12-06
     \ifdigitalcopy % Se for uma cópia digital
         \clearpage % Use apenas clearpage
     \else % Caso contrário, mantenha o comportamento original
-        \ifthenelse{\equal{\@folhaembranco}{true}{
+        \ifthenelse{\equal{\@folhaembranco}{false}{
 		\if@openright\cleardoublepage\else\clearpage\fi %% faz capitulo começar em folha impar (coloca folha em branco)
 	}{\vspace{\baselsinpe}}
 	\thispagestyle{\estilonum} %% define estilo de num. na pag. das partes 


### PR DESCRIPTION
Olá
Percebemos que o modelo o INPE tem algumas configurações que prejudicam a publicação de certos modelos de documentos

a primeira delas é o um bloco que força o início das paginações de capítulos em páginas impares

O segundo força uma nova pagina vazia entre capítulos

Pois bem, para documentos digitais de proposta, qualificação, etc... estas funções não fazem qualquer sentido.

Peço por gentiliza que analise a alteração proposta

Adicionada uma nova variável no preâmbulo para controlar se a cópia é digital:

\newif\ifdigitalcopy
\digitalcopyfalse % Por padrão, não é uma cópia digital

Para ativar a cópia digital, você simplesmente definiria \digitalcopytrue no seu documento LaTeX antes de \begin{document}.


para isso, foram modificados os comandos descritos anteriormente para que estes pudessem contemplar essa alteração 

assim, a paginação dos documentos digitais permanecem corretas, mesmo, sem a inserção de páginas em branco indesejadas.